### PR TITLE
Add --DontOptimize option

### DIFF
--- a/sdk/chustd/Png.cpp
+++ b/sdk/chustd/Png.cpp
@@ -86,7 +86,7 @@ bool Png::IsPng(IFile& file)
 {
 	const int32 signSize = sizeof(k_PngSignature);
 	uint8 aRead[signSize];
-	
+
 	if( file.Read(aRead, signSize) != signSize )
 	{
 		return false;
@@ -209,11 +209,11 @@ bool Png::LoadFromFile(IFile& file)
 	{
 		// End of stream with no damaged chunk but IEND not found
 		m_lastError = errNoIENDFound;
-		
+
 		// We set bOkHandled to false so we perform the needed on-error cleanup
 		bOkHandled = false;
 	}
-	
+
 	if( !bOkHandled )
 	{
 		// An error occurred, we clean the object except the lasterror field
@@ -319,7 +319,7 @@ int Png::Read_IHDR(IFile& file, int32 dataSizeof, PngChunk_IHDR& out)
 	{
 		return uncompleteFile;
 	}
-	
+
 	if( file.ShouldSwapBytes() )
 	{
 		out.SwapBytes();
@@ -428,7 +428,7 @@ bool Png::Handle_gAMA(IFile& file, int32 dataSizeof)
 		m_lastError = errNotEnoughDataInChunk;
 		return false;
 	}
-	
+
 	if( !file.Read32(m_gamma) )
 	{
 		m_lastError = uncompleteFile;
@@ -479,7 +479,7 @@ bool Png::Handle_bKGD(IFile& file, int32 dataSizeof)
 		}
 		return true;
 	}
-	
+
 	if( m_IHDR.colorType == 0x00 || m_IHDR.colorType == 0x04 )
 	{
 		// Grey or Grey+Alpha
@@ -504,7 +504,7 @@ bool Png::Handle_bKGD(IFile& file, int32 dataSizeof)
 			m_lastError = errNotEnoughDataInChunk;
 			return false;
 		}
-		
+
 		// TrueColor or TrueColor+Alpha
 		if( !(file.Read16(m_bkGD.red) && file.Read16(m_bkGD.green) && file.Read16(m_bkGD.blue)) )
 		{
@@ -651,7 +651,7 @@ bool Png::BeginImageDataProcessing()
 	{
 		// Uncompressing a frame
 		ApngFrame* pFrame = m_apFrames.GetLast();
-		
+
 		m_idiCurrent.pPixels = &(pFrame->m_pixels);
 		m_idiCurrent.width = pFrame->m_fctl.width;
 		m_idiCurrent.height = pFrame->m_fctl.height;
@@ -671,7 +671,7 @@ bool Png::BeginImageDataProcessing()
 
 	// The first time we meet an IDAT chunk, we initialize the zstream structure
 	m_deflateUncompressor.SetBuffers(nullptr, 0, nullptr, 0);
-	
+
 	const int nZErr = m_deflateUncompressor.Init();
 	if( nZErr != DF_RET_OK )
 	{
@@ -719,22 +719,22 @@ bool Png::ProcessImageData(IFile& file, int32 dataSizeof)
 		m_lastError = uncompleteFile;
 		return false;
 	}
-	
+
 	const uint32 availableOut = m_idiCurrent.uncompressedDataSize - m_outputOffset;
 
 	uint8* pIn  = m_compressedBuffer.GetPtr();
 	uint8* pOut = m_idiCurrent.pPixels->GetWritePtr() + m_outputOffset;
 	m_deflateUncompressor.SetBuffers(pIn, compressedSize, pOut, availableOut);
-	
+
 	int nZRet2 = m_deflateUncompressor.Uncompress(DF_FLUSH_SYNC);
-	
+
 	if( nZRet2 == DF_RET_OK )
 	{
-	
+
 	}
 	else if( nZRet2 == DF_RET_STREAM_END )
 	{
-	
+
 	}
 	else
 	{
@@ -762,19 +762,19 @@ bool Png::Handle_acTL(IFile& file, int32 dataSizeof)
 		m_lastError = errIDATFoundBeforeacTL;
 		return false;
 	}
-	
+
 	if( dataSizeof < 8 )
 	{
 		m_lastError = errNotEnoughDataInChunk;
 		return false;
 	}
-	
+
 	if( !(file.Read32(m_acTL.frameCount) && file.Read32(m_acTL.loopCount)) )
 	{
 		m_lastError = uncompleteFile;
-		return false;	
+		return false;
 	}
-	
+
 	if( m_acTL.frameCount == 0 )
 	{
 		// Not valid
@@ -808,14 +808,14 @@ bool Png::Handle_fcTL(IFile& file, int32 dataSizeof)
 	if( dataSizeof < wantedSizeof )
 	{
 		m_lastError = errNotEnoughDataInChunk;
-		return false;	
+		return false;
 	}
 
 	PngChunk_fcTL fctl;
 	if( file.Read(&fctl, wantedSizeof) != wantedSizeof )
 	{
 		m_lastError = uncompleteFile;
-		return false;	
+		return false;
 	}
 
 	if( file.ShouldSwapBytes() )
@@ -894,7 +894,7 @@ PixelFormat Png::GetPixelFormat(const PngChunk_IHDR& pngIHDR)
 
 PixelFormat Png::GetPixelFormat(uint8 colorType, uint8 bitDepth)
 {
-	// To the bottom : 
+	// To the bottom :
 	//   default: grey, flags: 0x1=palette used, 0x2=color used, 0x4=alpha used
 	// To the left :
 	//   Bit depth
@@ -936,7 +936,7 @@ const Buffer& Png::GetPixels() const
 		const int32 frameCount = m_apFrames.GetSize();
 		if( frameCount >= 0 )
 		{
-			// Yes, return the first frame, whose size and offset 
+			// Yes, return the first frame, whose size and offset
 			// must be compatible with what is stored in the IHDR
 			return m_apFrames[0]->GetPixels();
 		}
@@ -973,7 +973,7 @@ bool Png::EndImageDataProcessing()
 	else
 	{
 		// No interlacing, just unfilter
-		processingOk = UnfilterBlock(m_idiCurrent.pPixels->GetWritePtr(), 
+		processingOk = UnfilterBlock(m_idiCurrent.pPixels->GetWritePtr(),
 		                             m_idiCurrent.height, m_idiCurrent.byteWidth, m_sizeofPixel);
 		if( !processingOk )
 		{
@@ -996,7 +996,7 @@ uint8 Png::PaethPredictor(uint8 a, uint8 b, uint8 c)
 	int pa = b - c;
 	int pb = a - c;
 	int pc = pa + pb;
-	
+
 	if( pa < 0 ) { pa = -pa; }
 	if( pb < 0 ) { pb = -pb; }
 	if( pc < 0 ) { pc = -pc; }
@@ -1018,7 +1018,7 @@ bool Png::UnfilterAndUninterlace()
 	// Keep the previous data to be used as input in the unfiltering process
 	Buffer oldBuffer = *m_idiCurrent.pPixels;
 	m_idiCurrent.pPixels->SetSize(0);
-	
+
 	// *pPixels is now empty, we reallocate it as it will be used as output in the unfiltering process
 	// m_nUncompressedDataSize is modified too
 	if( !AllocateImageBuffer(false) )
@@ -1048,7 +1048,7 @@ bool Png::UnfilterAndUninterlace()
 
 	static const uint8 masks1[8] = { 0x80, 0x40, 0x20, 0x10, 0x08, 0x04, 0x02, 0x01 };
 	static const uint8 shifts1[8] = { 7, 6, 5, 4, 3, 2, 1, 0 };
-	
+
 	const uint8* paMask = nullptr;
 	const uint8* paShift = nullptr;
 	int32 dstShift = 0;
@@ -1082,11 +1082,11 @@ bool Png::UnfilterAndUninterlace()
 
 	// Current byte position in the interlaced buffer
 	int32 srcIndex = 0;
-	
+
 	// Sub index for pixel < 8 bits
 	int32 srcSubIndex = 0;
 	int32 maxSrcSubIndex = (8 / m_sizeofPixelInBits) - 1;
-	
+
 	for(int8 iPass = 0; iPass < 7; ++iPass)
 	{
 		//////////////////////////////////////////////////////////////////////////////
@@ -1144,7 +1144,7 @@ bool Png::UnfilterAndUninterlace()
 					byte &= paMask[srcSubIndex];
 					byte >>= paShift[srcSubIndex];
 					////////////////////////////////////
-					
+
 					////////////////////////////////////
 					int32 dstOffset = dstRowOffset + (col >> dstShift);
 					int32 dstSubIndex = col & maxSrcSubIndex;
@@ -1161,7 +1161,7 @@ bool Png::UnfilterAndUninterlace()
 						srcSubIndex = 0;
 					}
 				}
-				
+
 				col += aColIncrement[iPass];
 			}
 			while(col < width);
@@ -1213,7 +1213,7 @@ void Png::GetPassSize(int8 iPass, int32& rowCount, int32& pixelBytesPerRow,
 
 	int32 pixelsPerRow = (width + anAdders[iPass + 1]) / anDividers[iPass + 1];
 	int32 pixelBitsPerRow = pixelsPerRow * sizeofPixelInBits;
-	
+
 	pixelBytesPerRow = pixelBitsPerRow / 8 + ((pixelBitsPerRow % 8) > 0 ? 1 : 0);
 
 	rowCount = (height + anAdders[iPass]) / anDividers[iPass];
@@ -1273,7 +1273,7 @@ bool Png::UnfilterBlock(uint8* pBlock, int32 rowCount, int32 pixelBytesPerRow, i
 		tmpLine += 2;
 		tmpLine[2] = 0;
 		file.Write(line, (tmpLine-line)*2);
-		
+
 	}
 	file.Close();
 	*/
@@ -1293,13 +1293,13 @@ bool Png::UnfilterBlock(uint8* pBlock, int32 rowCount, int32 pixelBytesPerRow, i
 	{
 		// Initialize the index (iByte) of the current byte in the row
 		int32 iByte = 0;
-		
+
 		// Get the filtering method used for this row
 		const uint8 method = pRow[0];
-				
+
 		// Jump over the filtering method byte
 		pRow++;
-		
+
 		switch(method)
 		{
 		case 0:
@@ -1310,10 +1310,10 @@ bool Png::UnfilterBlock(uint8* pBlock, int32 rowCount, int32 pixelBytesPerRow, i
 				{
 					const uint8 pixel = pRow[0];
 					pRow++;
-					
+
 					pUnfilteredRow[0] = pixel;
 					pUnfilteredRow++;
-					
+
 				}
 				while(--counter > 0);
 			}
@@ -1491,7 +1491,7 @@ String Png::GetLastErrorString() const
 
 	case Png::errBadHeaderSize:
 		return "Invalid header size";
-		
+
 	case Png::errBadBitDepth:
 		return "Invalid bit depth";
 
@@ -1506,7 +1506,7 @@ String Png::GetLastErrorString() const
 
 	case Png::errBadFilterMethod:
 		return "Invalid or unsupported filtering method";
-		
+
 	case Png::errBadFilterType:
 		return "Bad filtering type";
 
@@ -1515,7 +1515,7 @@ String Png::GetLastErrorString() const
 
 	case Png::errBadPicSize:
 		return "Invalid image size";
-	
+
 	case Png::errNoIENDFound:
 		return "No IEND chunk found at the end of the file data (file corrupted)";
 
@@ -1548,13 +1548,13 @@ String Png::GetLastErrorString() const
 
 	case Png::erracTLRepeated:
 		return "acTL chunk repeated";
-	
+
 	case Png::errMissingfcTLBeforefdAT:
 		return "fcTL chunk missing before fdAT";
 
 	case Png::errUnexpectedChunk:
 		return "Unexpected chunk: " + StringFromChunkType(m_currentChunkType);
-		
+
 	case Png::errFrameCountMismatch:
 		return "Frame count mismatch with acTL";
 	case Png::errFrameCountOutsideRange:

--- a/sdk/poeng/POEngine.cpp
+++ b/sdk/poeng/POEngine.cpp
@@ -1891,7 +1891,7 @@ bool POEngine::OptimizeSingleFileNoBackup(IFile& fileImage, OptiTarget& target)
 		dd.textInfos[0] = text;
 	}
 
-	if (m_settings.dontOptimize) {
+	if (m_settings.keepPixels) {
 		return DumpBestResultToFile(target);
 	} else {
 		if (img.IsAnimated())

--- a/sdk/poeng/POEngine.cpp
+++ b/sdk/poeng/POEngine.cpp
@@ -1891,9 +1891,12 @@ bool POEngine::OptimizeSingleFileNoBackup(IFile& fileImage, OptiTarget& target)
 		dd.textInfos[0] = text;
 	}
 
-	if (m_settings.keepPixels) {
+	if (m_settings.keepPixels)
+  {
 		return DumpBestResultToFile(target);
-	} else {
+	}
+  else
+  {
 		if (img.IsAnimated())
 		{
 			return OptimizeAnimated(img, dd, target);

--- a/sdk/poeng/POEngine.cpp
+++ b/sdk/poeng/POEngine.cpp
@@ -63,7 +63,7 @@ DynamicMemoryFile& POEngine::ResultManager::GetCandidate()
 	DynamicMemoryFile& dmf = (size1 > size0) ? m_dmf1 : m_dmf0;
 
 	// Open the dynamic memory file with allocation performed
-	
+
 	// The -64 is to be gentle with the memory allocator that needs room for its headers
 	const int32 firstAlloc = 512 * 1024 - 64;
 	dmf.Open(firstAlloc);
@@ -140,7 +140,7 @@ bool POEngine::IsBlackAndWhite(const Palette& pal, bool& shouldSwap)
 	}
 	Color col0 = pal.m_colors[0];
 	Color col1 = pal.m_colors[1];
-	
+
 	shouldSwap = false;
 
 	if( col0.IsEqualRgb(Color::Black) && col1.IsEqualRgb(Color::White) )
@@ -308,8 +308,8 @@ bool POEngine::TryToConvertIndexedToBlackAndWhite(PngDumpData& dd)
 	}
 
 	uint8 nAlpha0 = dd.palette.m_colors[0].GetAlpha();
-	uint8 nAlpha1 = dd.palette.m_colors[1].GetAlpha(); 
-			
+	uint8 nAlpha1 = dd.palette.m_colors[1].GetAlpha();
+
 	if( (nAlpha0 != 255 || nAlpha1 != 255) && m_settings.avoidGreyWithSimpleTransparency )
 	{
 		// A black&white picture with transparency, we stay in palette mode
@@ -398,11 +398,11 @@ bool POEngine::TryToConvertIndexedToGreyscale(PngDumpData& dd)
 		return false;
 	}
 
-	// The colors are ok, now check the alphas. We need no transparency at all 
+	// The colors are ok, now check the alphas. We need no transparency at all
 	// or only one fully transparent color
 	uint8 alpha0 = dd.palette.m_colors[0].GetAlpha();
 	uint8 alpha1 = dd.palette.m_colors[1].GetAlpha();
-		
+
 	if( alpha0 == 255 )
 	{
 		// Full opaque image
@@ -474,7 +474,7 @@ bool POEngine::DumpBestResultToFile(OptiTarget& target)
 			AddError(k_szCannotWriteUncomplete);
 			return false;
 		}
-		
+
 		// Write the same modification date than the original file.
 		// This should be done just before closing, because Write()
 		// will update the modification date too
@@ -527,9 +527,9 @@ static void AddFrameColorCounts(const ApngFrame* pFrame, uint32* pCounts)
 static void CountColors(const PngDumpData& dd, uint32* pCounts)
 {
 	ASSERT( dd.pixelFormat == PF_8bppIndexed );
-	
+
 	Memory::Zero32(pCounts, 256);
-	
+
 	const int frameCount = dd.frames.GetSize();
 
 	if( dd.hasDefaultImage || frameCount == 0 )
@@ -541,7 +541,7 @@ static void CountColors(const PngDumpData& dd, uint32* pCounts)
 			pCounts[ pPixels[i] ]++;
 		}
 	}
-	
+
 	for(int iFrame = 0; iFrame < frameCount; ++iFrame)
 	{
 		const ApngFrame* pFrame = dd.frames[iFrame];
@@ -561,11 +561,11 @@ bool POEngine::OptimizePaletteMode(PngDumpData& dd)
 	ASSERT( PF_1bppIndexed <= dd.pixelFormat && dd.pixelFormat <= PF_8bppIndexed);
 
 	UnpackPixelFrames(dd);
-	
+
 	// Count the number of times a color appears
 	uint32 colCounts[256];
 	CountColors(dd, colCounts);
-	
+
 	// Remove holes in the palette and create the conversion table old index -> new index
 	PaletteTranslator noHolesTranslator;
 	noHolesTranslator.BuildUnusedColors(dd.palette, colCounts);
@@ -635,7 +635,7 @@ bool POEngine::OptimizePaletteMode(PngDumpData& dd)
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 // Find an unused color among the pixels
 // Needs memory allocation, thus can fail
-bool POEngine::FindUnusedColorHardcoreMethod(const uint8* pRgba, int32 pixelCount, 
+bool POEngine::FindUnusedColorHardcoreMethod(const uint8* pRgba, int32 pixelCount,
                                              uint8& nRed, uint8& nGreen, uint8& nBlue)
 {
 	ByteArray aSorted;
@@ -685,13 +685,13 @@ bool POEngine::FindUnusedColorHardcoreMethod(const uint8* pRgba, int32 pixelCoun
 		// Like a 4096*4096 picture
 		return false;
 	}
-	
+
 	uint32 nColor = nA + 1;
 
 	nRed = uint8(nColor & 0x000000ff);
 	nGreen = uint8((nColor & 0x0000ff00) >> 8);
 	nBlue = uint8((nColor & 0x00ff0000) >> 16);
-	
+
 	return true;
 }
 
@@ -714,9 +714,9 @@ bool POEngine::FindUnusedColor(const Buffer& aRgb, uint8& nRed, uint8& nGreen, u
 	aCandidates[4].SetRgb(0, 0, 1);
 	aCandidates[5].SetRgb(1, 0, 1);
 	aCandidates[6].SetRgb(0, 1, 0);
-	
+
 	const int32 pixelCount = aRgb.GetSize() / 3;
-	
+
 	foreach(aCandidates, iCandidate)
 	{
 		bool bGoodCandidate = true;
@@ -793,7 +793,7 @@ bool POEngine::Optimize32BitsMode(PngDumpData& dd)
 
 	///////////////////////////////////////////////////////////////////////////////////////////////
 	// First step : set to 0 every color which alpha is 0
-	
+
 	// It will allow a potential optimisation 32 bits --> palette mode
 	// We set the fully transparent color to 0 as 4 bytes to 0 are nicely compressed
 
@@ -853,7 +853,7 @@ bool POEngine::Optimize32BitsMode(PngDumpData& dd)
 		pNewBuffer[2] = b;
 
 		alphaCounts[alpha] += 1;
-		
+
 		pSrcBuffer += 4;
 		pNewBuffer += 3;
 	}
@@ -877,10 +877,10 @@ bool POEngine::Optimize32BitsMode(PngDumpData& dd)
 
 		////////////////////////////////////////////////////
 		// First, check if black is a used color
-		
+
 		bool bBlackAsTransparentColor = CanBlackBeUsedAsTransparentColor32BppRGBX(dd);
 		////////////////////////////////////////////////////
-		
+
 		uint8 nTransRed = 0;
 		uint8 nTransGreen = 0;
 		uint8 nTransBlue = 0;
@@ -911,13 +911,13 @@ bool POEngine::Optimize32BitsMode(PngDumpData& dd)
 						pPixelsRgb[1] = nTransGreen;
 						pPixelsRgb[2] = nTransBlue;
 					}
-					
+
 					pPixelsRgba += 4;
 					pPixelsRgb += 3;
 				}
 			}
 		}
-		
+
 		if( bContinueIn24Bits )
 		{
 			// Now we have our 24 bits image + one color for transparency, continue with 24 bits optimization...
@@ -970,7 +970,7 @@ bool POEngine::Optimize24BitsMode(PngDumpData& dd)
 		uint8 r = pSrcBuffer[0];
 		uint8 g = pSrcBuffer[1];
 		uint8 b = pSrcBuffer[2];
-		
+
 		// Find the color in the palette
 		int32 iCol = 0;
 		for(; iCol < palTest.m_count; ++iCol)
@@ -1016,7 +1016,7 @@ bool POEngine::Optimize24BitsMode(PngDumpData& dd)
 	{
 		bTooMuchColors = true;
 	}
-	
+
 	///////////////////////////////////////////////////////////////////
 	//dd.pBuffer = pBuffer;
 	dd.pixelFormat = PF_24bppRgb;
@@ -1100,7 +1100,7 @@ int POEngine::CanSimplifyGreyAlpha(const PngDumpData& dd) const
 			}
 		}
 	}
-	
+
 	for(int iFrame = 0; iFrame < frameCount; ++iFrame)
 	{
 		const ApngFrame* pFrame = dd.frames[iFrame];
@@ -1181,7 +1181,7 @@ bool POEngine::OptimizeGrayScaleAlpha(PngDumpData& dd)
 		}
 		dd.pixels.SetSize(pixelCount); // Shrink buffer
 	}
-	
+
 	for(int iFrame = 0; iFrame < frameCount; ++iFrame)
 	{
 		ApngFrame* pFrame = dd.frames[iFrame];
@@ -1425,7 +1425,7 @@ bool POEngine::InsertCleanOriginalPngAsResult(IFile& file)
 
 	DynamicMemoryFile& dmf = m_resultmgr.GetCandidate();
 	dmf.SetByteOrder(boBigEndian);
-	
+
 	// Ensure capacity
 	if( !dmf.EnsureCapacity(fileSize32) )
 	{
@@ -1753,7 +1753,7 @@ bool POEngine::OptimizeSingleFileNoBackup(IFile& fileImage, OptiTarget& target)
 
 		// Insert a clean version of the source PNG
 		// "clean" means the same PNG expect some unwanted chunks (like the gamma chunk)
-		
+
 		// As we insert a copy of the source file, the source file becomes a candidate for the best result,
 		// thus if we cannot achieve a better compression than the original file, we just dump the original file
 		dmfAsIs.SetPosition(0);
@@ -1770,10 +1770,10 @@ bool POEngine::OptimizeSingleFileNoBackup(IFile& fileImage, OptiTarget& target)
 	if( !loadOk )
 	{
 		String strImgErr = img.GetLastErrorString();
-		
+
 		String strErr = "Cannot load image: ";
 		strErr = strErr + strImgErr;
-		
+
 		AddError(strErr);
 		return false;
 	}
@@ -1783,7 +1783,7 @@ bool POEngine::OptimizeSingleFileNoBackup(IFile& fileImage, OptiTarget& target)
 	const Buffer& pixels = img.GetPixels();
 	const Palette& palette = img.GetPalette();
 	PixelFormat pf = img.GetPixelFormat();
-	
+
 	//////////////////////////////////////////////////////////////
 	PngDumpData dd; // Final dump structure
 	dd.width = width;
@@ -1891,11 +1891,15 @@ bool POEngine::OptimizeSingleFileNoBackup(IFile& fileImage, OptiTarget& target)
 		dd.textInfos[0] = text;
 	}
 
-	if( img.IsAnimated() )
-	{
-		return OptimizeAnimated(img, dd, target);
+	if (m_settings.dontOptimize) {
+		return DumpBestResultToFile(target);
+	} else {
+		if (img.IsAnimated())
+		{
+			return OptimizeAnimated(img, dd, target);
+		}
+		return Optimize(dd, target);
 	}
-	return Optimize(dd, target);
 }
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////
@@ -1909,7 +1913,7 @@ void POEngine::PrintSizeChange(int64 sizeBefore, int64 sizeAfter)
 	int64 ratio = sizeAfter;
 	ratio *= 100;
 	ratio /= sizeBefore;
-			
+
 	String arrow;
 	if( m_unicodeArrowEnabled )
 	{
@@ -1922,7 +1926,7 @@ void POEngine::PrintSizeChange(int64 sizeBefore, int64 sizeAfter)
 	}
 	StringBuilder sb;
 	PrintText(String::FromInt64(sizeBefore), TT_SizeInfoNum);
-	PrintText(" bytes "+arrow+" ", TT_SizeInfo); 
+	PrintText(" bytes "+arrow+" ", TT_SizeInfo);
 	PrintText(String::FromInt64(sizeAfter), TT_SizeInfoNum);
 	PrintText(" bytes", TT_SizeInfo);
 
@@ -1998,7 +2002,7 @@ bool POEngine::OptimizeSingleFile(const String& filePath, const String& displayD
 		PrintText("Converting ", TT_ActionVerb);
 	}
 	///////////////////////////////////////////////////////////////////////
-	
+
 	if( !displayDir.IsEmpty() )
 	{
 		// Display the sub-directory
@@ -2014,7 +2018,7 @@ bool POEngine::OptimizeSingleFile(const String& filePath, const String& displayD
 
 	String oldFilePath;
 	String newFilePath;
-	
+
 	// If the source file is a PNG, we rename that source file with a "_" at the beginning of its name
 	if( fileExt == "png" || fileExt == "apng" )
 	{
@@ -2090,7 +2094,7 @@ bool POEngine::OptimizeSingleFile(const String& filePath, const String& displayD
 // [in] joker         Type of files managed
 // [in,out] optiInfo  Optimization information
 ///////////////////////////////////////////////////////////////////////////////////////////////////
-void POEngine::OptimizeFilesInternal(const String& baseDir, const StringArray& fileNames, const String& displayDir, 
+void POEngine::OptimizeFilesInternal(const String& baseDir, const StringArray& fileNames, const String& displayDir,
                                      const String& joker, OptiInfo& optiInfo)
 {
 	const int32 fileCount = fileNames.GetSize();
@@ -2157,7 +2161,7 @@ void POEngine::OptimizeFilesInternal(const String& baseDir, const StringArray& f
 //
 // [in] filePaths  Absolute file paths of files or directories to optimize
 // [in] joker      File types handled. ex: "*.png" or "*.gif|*.bmp"
-// 
+//
 // Returns true if all filtered files could be optimized or converted,
 //         false if at least one error was raised during the call.
 ///////////////////////////////////////////////////////////////////////////////////////////////////
@@ -2184,7 +2188,7 @@ bool POEngine::OptimizeFiles(const StringArray& filePaths, const String& joker)
 		// OptimizeFilesInternal will silently filter out files that are not supported.
 		// However, for a public function, when no file at all is optimized, this is
 		// considered as an error.
-		if( optiInfo.optiCount == 0 && optiInfo.errorCount == 0 
+		if( optiInfo.optiCount == 0 && optiInfo.errorCount == 0
 		 && filePaths.GetSize() == 1 && File::Exists(filePaths[0]) )
 		{
 			PrintText(String(k_szUnsupportedFileType) + ": " + FilePath::GetName(filePaths[0]) + "\n", TT_ErrorMsg);
@@ -2465,7 +2469,7 @@ void MergePalettes(const ImageFormat& img, PngDumpData& dd)
 		}
 		frameNewPals[iFrame] = fnp;
 	}
-		
+
 	////////////////////////////////////////////////////////////////////
 	// Choose between Color and RGBA when switching to true colors
 	if( switchToTrueColors && hasTransparency )
@@ -2485,7 +2489,7 @@ void MergePalettes(const ImageFormat& img, PngDumpData& dd)
 			// Palette mode, look in the super palette
 			if( !hasTransparency )
 			{
-				// No transparent color to be used to create the default image. 
+				// No transparent color to be used to create the default image.
 				// Try to add a new entry in the palette
 				if( superPalette.m_count < 255 )
 				{
@@ -2523,7 +2527,7 @@ void MergePalettes(const ImageFormat& img, PngDumpData& dd)
 			int pixelCount = pFrame->m_fctl.width * pFrame->m_fctl.height;
 			uint8* pPixels = pFrame->m_pixels.GetWritePtr();
 			ASSERT(pFrame->m_pixels.GetSize() == pixelCount);
-					
+
 			fnp.translator.Translate(pPixels, pixelCount);
 		}
 	}
@@ -2538,7 +2542,7 @@ void MergePalettes(const ImageFormat& img, PngDumpData& dd)
 			int dstPixelSize = switchToRgba ? 4 : 3;
 			const int32 nPixCount = pDst->m_fctl.width * pDst->m_fctl.height;
 			pDst->m_pixels.SetSize(nPixCount * dstPixelSize);
-						
+
 			const uint8* pSrcPixels = pSrc->GetPixels().GetReadPtr();
 			uint8* pDstPixels = pDst->m_pixels.GetWritePtr();
 			const Palette* pPalette = &(pSrc->GetPalette());
@@ -2551,7 +2555,7 @@ void MergePalettes(const ImageFormat& img, PngDumpData& dd)
 				{
 					uint8 r, g, b, a;
 					pPalette->m_colors[ pSrcPixels[iPix] ].ToRgba(r, g, b, a);
-							
+
 					pDstPixels[0] = r;
 					pDstPixels[1] = g;
 					pDstPixels[2] = b;
@@ -2567,7 +2571,7 @@ void MergePalettes(const ImageFormat& img, PngDumpData& dd)
 				{
 					uint8 r, g, b, a;
 					pPalette->m_colors[ pSrcPixels[iPix] ].ToRgba(r, g, b, a);
-							
+
 					pDstPixels[0] = r;
 					pDstPixels[1] = g;
 					pDstPixels[2] = b;
@@ -2594,9 +2598,9 @@ void MergePalettes(const ImageFormat& img, PngDumpData& dd)
 
 		const uint8* pSrc = oldPixels.GetReadPtr();
 		uint8* pDst = dd.frames[0]->m_pixels.GetWritePtr();
-			
+
 		int bytesPerPixel = ImageFormat::SizeofPixelInBits(dd.pixelFormat) / 8;
-			
+
 		// Fill with transparent color
 		if( bytesPerPixel == 1 )
 		{
@@ -2647,19 +2651,19 @@ bool POEngine::OptimizeAnimated(const ImageFormat& img, PngDumpData& dd, OptiTar
 	{
 		return false;
 	}
-	
+
 	// Fills the dump settings
 	PrepareAnimatedDumpSettings(img, dd);
-	
+
 	// Unpack pixels to 8 bits per pixel if indexed to make treatment easier
 	UnpackPixelFrames(dd);
-	
+
 	// Merge palettes if frame local palettes are found (GIF)
 	// The pixel format can switch to Color or RGBA
 	MergePalettes(img, dd);
-	
+
 	dd.interlaced = false; // Always to false with animation
-	
+
 	PngDumpSettings ds;
 	ds.filtering = 0;
 	ds.zlibCompressionLevel = 9;

--- a/sdk/poeng/POEngineSettings.cpp
+++ b/sdk/poeng/POEngineSettings.cpp
@@ -15,6 +15,7 @@ static const char k_szKeepInterlacing[]       = "KeepInterlacing";
 static const char k_szAvoidGreyWithSimpleTransparency[] = "AvoidGreyWithSimpleTransparency";
 static const char k_szIgnoreAnimatedGifs[]    = "IgnoreAnimatedGifs";
 static const char k_szKeepFileDate[]          = "KeepFileDate";
+static const char k_szDontOptimize[]          = "DontOptimize";
 
 static const char k_szKeepBackgroundColor[]   = "KeepBackgroundColor";
 static const char k_szForcedBackgroundColor[] = "ForcedBackgroundColor";
@@ -40,6 +41,7 @@ POEngineSettings::POEngineSettings()
 	avoidGreyWithSimpleTransparency = false;
 	ignoreAnimatedGifs = false;
 	keepFileDate = false;
+	dontOptimize = false;
 
 	bkgdOption = POChunk_Remove;
 	textOption = POChunk_Remove;
@@ -82,6 +84,7 @@ void POEngineSettings::LoadFromIni(const MemIniFile& ini)
 	ini.GetBool(k_szAvoidGreyWithSimpleTransparency, avoidGreyWithSimpleTransparency);
 	ini.GetBool(k_szIgnoreAnimatedGifs, ignoreAnimatedGifs);
 	ini.GetBool(k_szKeepFileDate, keepFileDate);
+	ini.GetBool(k_szDontOptimize, dontOptimize);
 
 	int optionInt = int(bkgdOption);
 	ini.GetInt(k_szKeepBackgroundColor, optionInt);
@@ -137,6 +140,7 @@ void POEngineSettings::SaveToIni(MemIniFile& ini) const
 	ini.SetBool(k_szAvoidGreyWithSimpleTransparency, avoidGreyWithSimpleTransparency);
 	ini.SetBool(k_szIgnoreAnimatedGifs, ignoreAnimatedGifs);
 	ini.SetBool(k_szKeepFileDate,       keepFileDate);
+	ini.SetBool(k_szDontOptimize,       dontOptimize);
 
 	ini.SetInt(k_szKeepBackgroundColor, bkgdOption);
 	uint8 r, g, b;
@@ -169,7 +173,7 @@ POChunkOption GetChunkOption(const ArgvParser& ap, const String& optionName)
 	if( ap.HasFlag(optionName) )
 	{
 		chunkOption = POChunk_Keep;
-		
+
 		String strKbcOption = ap.GetFlagString(optionName);
 		if( strKbcOption == "0" || strKbcOption == "R" )
 		{
@@ -193,6 +197,7 @@ void POEngineSettings::LoadFromArgv(const ArgvParser& ap)
 	avoidGreyWithSimpleTransparency = ap.HasFlag(k_szAvoidGreyWithSimpleTransparency);
 	ignoreAnimatedGifs = ap.HasFlag(k_szIgnoreAnimatedGifs);
 	keepFileDate = ap.HasFlag(k_szKeepFileDate);
+	dontOptimize = ap.HasFlag(k_szDontOptimize);
 
 	bkgdOption = GetChunkOption(ap, k_szKeepBackgroundColor);
 
@@ -211,7 +216,7 @@ void POEngineSettings::LoadFromArgv(const ArgvParser& ap)
 			bkgdColor.SetRgb(uint8(bkR), uint8(bkG), uint8(bkB));
 		}
 	}
-	
+
 	///////////////////////////////////////////
 	textOption = GetChunkOption(ap, k_szKeepTextualData);
 	textKeyword = ap.GetFlagString(k_szForcedTextKeyword);

--- a/sdk/poeng/POEngineSettings.cpp
+++ b/sdk/poeng/POEngineSettings.cpp
@@ -15,7 +15,7 @@ static const char k_szKeepInterlacing[]       = "KeepInterlacing";
 static const char k_szAvoidGreyWithSimpleTransparency[] = "AvoidGreyWithSimpleTransparency";
 static const char k_szIgnoreAnimatedGifs[]    = "IgnoreAnimatedGifs";
 static const char k_szKeepFileDate[]          = "KeepFileDate";
-static const char k_szDontOptimize[]          = "DontOptimize";
+static const char k_szKeepPixels[]          = "KeepPixels";
 
 static const char k_szKeepBackgroundColor[]   = "KeepBackgroundColor";
 static const char k_szForcedBackgroundColor[] = "ForcedBackgroundColor";
@@ -41,7 +41,7 @@ POEngineSettings::POEngineSettings()
 	avoidGreyWithSimpleTransparency = false;
 	ignoreAnimatedGifs = false;
 	keepFileDate = false;
-	dontOptimize = false;
+	keepPixels = false;
 
 	bkgdOption = POChunk_Remove;
 	textOption = POChunk_Remove;
@@ -84,7 +84,7 @@ void POEngineSettings::LoadFromIni(const MemIniFile& ini)
 	ini.GetBool(k_szAvoidGreyWithSimpleTransparency, avoidGreyWithSimpleTransparency);
 	ini.GetBool(k_szIgnoreAnimatedGifs, ignoreAnimatedGifs);
 	ini.GetBool(k_szKeepFileDate, keepFileDate);
-	ini.GetBool(k_szDontOptimize, dontOptimize);
+	ini.GetBool(k_szKeepPixels, keepPixels);
 
 	int optionInt = int(bkgdOption);
 	ini.GetInt(k_szKeepBackgroundColor, optionInt);
@@ -140,7 +140,7 @@ void POEngineSettings::SaveToIni(MemIniFile& ini) const
 	ini.SetBool(k_szAvoidGreyWithSimpleTransparency, avoidGreyWithSimpleTransparency);
 	ini.SetBool(k_szIgnoreAnimatedGifs, ignoreAnimatedGifs);
 	ini.SetBool(k_szKeepFileDate,       keepFileDate);
-	ini.SetBool(k_szDontOptimize,       dontOptimize);
+	ini.SetBool(k_szKeepPixels,       keepPixels);
 
 	ini.SetInt(k_szKeepBackgroundColor, bkgdOption);
 	uint8 r, g, b;
@@ -197,7 +197,7 @@ void POEngineSettings::LoadFromArgv(const ArgvParser& ap)
 	avoidGreyWithSimpleTransparency = ap.HasFlag(k_szAvoidGreyWithSimpleTransparency);
 	ignoreAnimatedGifs = ap.HasFlag(k_szIgnoreAnimatedGifs);
 	keepFileDate = ap.HasFlag(k_szKeepFileDate);
-	dontOptimize = ap.HasFlag(k_szDontOptimize);
+	keepPixels = ap.HasFlag(k_szKeepPixels);
 
 	bkgdOption = GetChunkOption(ap, k_szKeepBackgroundColor);
 
@@ -255,6 +255,7 @@ void POEngineSettings::WriteArgvUsage(const String& indent)
 	Console::WriteLine(indent + "[-" + String(k_szAvoidGreyWithSimpleTransparency) + "]");
 	Console::WriteLine(indent + "[-" + String(k_szIgnoreAnimatedGifs) + "]");
 	Console::WriteLine(indent + "[-" + String(k_szKeepFileDate) + "]");
+	Console::WriteLine(indent + "[-" + String(k_szKeepPixels) + "]");
 	Console::WriteLine(indent + "[-" + String(k_szKeepBackgroundColor) + "][:R|K|F] [-" + String(k_szForcedBackgroundColor) + ":RRGGBB]");
 	Console::WriteLine(indent + "[-" + String(k_szKeepTextualData) + "][:R|K|F]     [-" + String(k_szForcedTextKeyword) + ":Foo] [-" 
 	                                                                                    + String(k_szForcedTextData) + ":Bar]");

--- a/sdk/poeng/POEngineSettings.h
+++ b/sdk/poeng/POEngineSettings.h
@@ -25,7 +25,7 @@ struct POEngineSettings
 	bool avoidGreyWithSimpleTransparency;
 	bool ignoreAnimatedGifs;
 	bool keepFileDate;
-	bool dontOptimize;
+	bool keepPixels;
 
 	POChunkOption  bkgdOption;
 	chustd::Color  bkgdColor; // Forced color

--- a/sdk/poeng/POEngineSettings.h
+++ b/sdk/poeng/POEngineSettings.h
@@ -25,6 +25,7 @@ struct POEngineSettings
 	bool avoidGreyWithSimpleTransparency;
 	bool ignoreAnimatedGifs;
 	bool keepFileDate;
+	bool dontOptimize;
 
 	POChunkOption  bkgdOption;
 	chustd::Color  bkgdColor; // Forced color
@@ -47,7 +48,7 @@ struct POEngineSettings
 	void SaveToIni(chustd::MemIniFile& ini) const;
 
 	static void WriteArgvUsage(const chustd::String& indent);
-	
+
 	// Sometimes it easier for the user to enter values in PPI, so we offer
 	// some conversion functions
 	static int PpiFromPpm(int ppm);

--- a/unit_tests/poeng_ut/POEngineSettings_Test.cpp
+++ b/unit_tests/poeng_ut/POEngineSettings_Test.cpp
@@ -29,7 +29,7 @@ const String k_iniSection = "PoeSettings";
 void ToIni(const POEngineSettings& settings)
 {
 	File::Delete(k_iniFilePath);
-	
+
 	MemIniFile iniSave;
 	iniSave.SetSection(k_iniSection);
 	settings.SaveToIni(iniSave);
@@ -54,7 +54,7 @@ TEST(POEngineSettings, EmptyArgv)
 
 	POEngineSettings settings;
 	settings.LoadFromArgv(ap);
-	
+
 	POEngineSettings exp;
 	exp.backupOldPngFiles = false; // The only difference with INI loading
 	ASSERT_TRUE(settings == exp);
@@ -71,19 +71,21 @@ TEST(POEngineSettings, AllArgv)
 		"-KeepFileDate",
 		"-KeepBackgroundColor",
 		"-KeepTextualData",
-		"-KeepPhysicalPixelDimensions"
+		"-KeepPhysicalPixelDimensions",
+		"-KeepPixels"
 	};
 	ArgvParser ap(ARRAY_SIZE(argv), argv);
 
 	POEngineSettings settings;
 	settings.LoadFromArgv(ap);
-	
+
 	POEngineSettings exp;
 	exp.backupOldPngFiles = true;
 	exp.keepInterlacing = true;
 	exp.avoidGreyWithSimpleTransparency = true;
 	exp.ignoreAnimatedGifs = true;
 	exp.keepFileDate = true;
+	exp.keepPixels = true;
 	exp.bkgdOption = POChunk_Keep;
 	exp.textOption = POChunk_Keep;
 	exp.physOption = POChunk_Keep;
@@ -107,7 +109,7 @@ TEST(POEngineSettings, RemoveChunkArgv)
 
 	POEngineSettings settings;
 	settings.LoadFromArgv(ap);
-	
+
 	POEngineSettings exp;
 	exp.backupOldPngFiles = false;
 	exp.bkgdOption = POChunk_Remove;
@@ -139,7 +141,7 @@ TEST(POEngineSettings, KeepChunkArgv)
 
 	POEngineSettings settings;
 	settings.LoadFromArgv(ap);
-	
+
 	POEngineSettings exp;
 	exp.backupOldPngFiles = false;
 	exp.bkgdOption = POChunk_Keep;
@@ -166,14 +168,14 @@ TEST(POEngineSettings, ForceChunkArgv)
 {
 	const char* argv[] = {
 		"app.exe",
-		
+
 		"-KeepBackgroundColor:2",
 		"-ForcedBackgroundColor:a1b2c3",
 
 		"-KeepTextualData:2",
 		"-ForcedTextKeyword:" UTF8_CAPITAL_E_WITH_ACUTE "toffe",
 		"-ForcedTextData:Soie brod" UTF8_SMALL_E_WITH_ACUTE "e",
-		
+
 		"-KeepPhysicalPixelDimensions:2",
 		"-ForcedPixelsPerMeter:2000x1000"
 	};
@@ -181,7 +183,7 @@ TEST(POEngineSettings, ForceChunkArgv)
 
 	POEngineSettings settings;
 	settings.LoadFromArgv(ap);
-	
+
 	POEngineSettings exp;
 	exp.backupOldPngFiles = false;
 	exp.bkgdOption = POChunk_Force;
@@ -196,14 +198,14 @@ TEST(POEngineSettings, ForceChunkArgv)
 
 	const char* argvAlt[] = {
 		"app.exe",
-		
+
 		"-KeepBackgroundColor:F",
 		"-ForcedBackgroundColor:a1b2c3",
 
 		"-KeepTextualData:F",
 		"-ForcedTextKeyword:" UTF8_CAPITAL_E_WITH_ACUTE "toffe",
 		"-ForcedTextData:Soie brod" UTF8_SMALL_E_WITH_ACUTE "e",
-		
+
 		"-KeepPhysicalPixelDimensions:F",
 		"-ForcedPixelsPerMeter:2000x1000"
 	};
@@ -230,7 +232,7 @@ TEST(POEngineSettings, ForcePixelsPerInchArgv)
 
 	POEngineSettings settings;
 	settings.LoadFromArgv(ap);
-	
+
 	POEngineSettings exp;
 	exp.backupOldPngFiles = false;
 	exp.physOption = POChunk_Force;


### PR DESCRIPTION
For a case of having lots of PNGs with large text chunks I want to preserve as much from idat, but remove those chunks only. e.g. we had some PNG files ~200x200px with a size of 7Mb 99% of it is Photoshop generated XMP metadata which somehow got there.

Preserving everything from idat may be useful in rare cases. (gamedev asset pipeline)
Also some tools in our studio don't support anything other than 24bpp and 32bpp.

Sorry for lots of whitespace related changes squashed in single commit.